### PR TITLE
add (hidden) support for opening urls in tabs

### DIFF
--- a/popup/popup.html
+++ b/popup/popup.html
@@ -14,7 +14,7 @@
     <main>
         <header>
             <h1>Export Tabs URLs</h1>
-            <p class="popup-counter"></p>
+            <p class="popup-counter" data-i18n="popupCounter"></p>
         </header>
 
         <p class="popup-filter-tabs-container hidden">

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -36,6 +36,10 @@ w.addEventListener('load', function () {
 
   setLimitWindowVisibility()
 
+  popupCounter.addEventListener('click', function () {
+    openUrlsInTabs()
+  })
+
   popupFormat.addEventListener('change', function () {
     savePopupStates()
     updatePopup()
@@ -130,6 +134,16 @@ function updatePopup () {
       popupFilterTabs.focus()
     }
   )
+}
+
+function openUrlsInTabs() {
+  var urlRegex = /(https?:\/\/[^\s]+)/g;
+  let matches = popupTextarea.value.match(urlRegex);
+  matches.forEach(i => {
+    browser.tabs.create({
+      url: i
+    });
+  })
 }
 
 function filterMatch (needle, haystack) {


### PR DESCRIPTION
As it has been so long since this feature was requested, I figured I'd add simple support as a hidden feature, then @alct can style it in the UX at a later date if desired. This addresses #11 

Flow:
1. User pastes text containing urls into the text area
2. User clicks the counter
3. Tabs open

Note, I don't see any UX issues with this, aside from it being a hidden feature. When the tabs open, the textarea automatically updates with the correct list of urls again, so this simple addition 'just works'