### PR TITLE
exclude hidden tabs

### DIFF
--- a/_locales/en_US/messages.json
+++ b/_locales/en_US/messages.json
@@ -65,6 +65,9 @@
     "popupLabelFormatCustom": {
         "message": "Custom format"
     },
+    "popupLabelExcludeHidden":{
+        "message": "Exclude hidden tabs"
+    },
     "popupLabelFormatTitles": {
         "message": "Include titles"
     },

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -29,7 +29,10 @@
                 <label for="popup-format" class="popup-label-format-custom hidden" data-i18n="popupLabelFormatCustom"></label>
                 <label for="popup-format" class="popup-label-format-titles" data-i18n="popupLabelFormatTitles"></label>
             </p>
-
+            <p>
+                <input type="checkbox" id="popup-exclude-hidden-tabs" />
+                <label for="popup-exclude-hidden-tabs" class="popup-label-non-hidden" data-i18n="popupLabelExcludeHidden" title="Useful if you are using &#013;tab-grouping extensions like STG"></label>
+            </p>
             <p class="hidden">
                 <input type="checkbox" id="popup-limit-window" />
                 <label for="popup-limit-window" data-i18n="popupLimitWindow"></label>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -8,6 +8,7 @@ var
 var defaultPopupStates = {
   'states': {
     format: false,
+    excludehiddentabs: false,
     popupLimitWindow: false
   }
 }
@@ -27,6 +28,7 @@ w.addEventListener('load', function () {
   popupTextarea = d.getElementsByClassName('popup-textarea')[0]
   popupTextareaContainer = d.getElementsByClassName('popup-textarea-container')[0]
   popupFormat = d.getElementById('popup-format')
+  popupExcludeHiddenTabs = d.getElementById('popup-exclude-hidden-tabs')
   popupLabelFormatTitles = d.getElementsByClassName('popup-label-format-titles')[0]
   popupLabelFormatCustom = d.getElementsByClassName('popup-label-format-custom')[0]
   popupLimitWindow = d.getElementById('popup-limit-window')
@@ -37,6 +39,11 @@ w.addEventListener('load', function () {
   setLimitWindowVisibility()
 
   popupFormat.addEventListener('change', function () {
+    savePopupStates()
+    updatePopup()
+  })
+
+  popupExcludeHiddenTabs.addEventListener('change', function () {
     savePopupStates()
     updatePopup()
   })
@@ -96,6 +103,9 @@ function updatePopup () {
         var tabPinned = tabs[i].pinned
         var tabURL = tabs[i].url
         var tabTitle = tabs[i].title
+        var tabHidden = tabs[i].hidden
+
+        if (popupExcludeHiddenTabs.checked && tabHidden==true) continue;
 
         if (optionsIgnorePinned && tabPinned) continue
         if (popupLimitWindow.checked && tabWindowId !== currentWindowId) continue
@@ -205,6 +215,7 @@ function restorePopupStates () {
   gettingItem.then(function (items) {
     popupLimitWindow.checked = items.states.popupLimitWindow
     popupFormat.checked = items.states.format
+    popupExcludeHiddenTabs.checked = items.states.excludehiddentabs
 
     updatePopup()
   })
@@ -214,6 +225,7 @@ function savePopupStates () {
   browser.storage.local.set({
     'states': {
       format: popupFormat.checked,
+      excludehiddentabs: popupExcludeHiddenTabs.checked,
       popupLimitWindow: popupLimitWindow.checked
     }
   })


### PR DESCRIPTION
Hello,
This commit adds a checkbox that allows you to exclude hidden tabs from the export list.
This is very useful if you use extensions like Simple Tab Groups, which hides many tabs from non-active tab groups.. This option allows you to export only the active (visible) tabs.
![export-tabs-urls](https://github.com/alct/export-tabs-urls/assets/16746849/238ecdae-5246-4cee-85ad-8ccb4ab43bd2)

I would really appreciate if you can merge this PR, as I am actively using your original extension.